### PR TITLE
Remove install of gcc 4.8 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,10 @@ node_js:
   - 6
 matrix:
     fast_finish: true
-    allow_failures:
 env:
   global:
     - BUILD_LEADER_ID=2
-    - CXX=g++-4.8
 script: "npm run travis"
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
 before_install:
   - npm i -g npm@^2.0.0
 before_script:


### PR DESCRIPTION
Now that TravisCI [defaults to Ubuntu 14](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status), we no longer need to install a newer version of GCC in our Travis builds.

This installation process can take up to 2 minutes (and our builds are usually under 4 minutes), meaning this change makes Travis run twice as fast!!

Connects pelias/pelias#575